### PR TITLE
Covid Rules check if the rules list is long enough before accessing it

### DIFF
--- a/source/data/data.json
+++ b/source/data/data.json
@@ -1,1 +1,27 @@
-{}
+{
+    "5675094723": {
+        "current_state": 0,
+        "receive_warnings": true,
+        "receive_covid_information": 0,
+        "default_level": "Manual",
+        "locations": {},
+        "recommendations": [
+            {
+                "name": "Berlin, Stadt",
+                "place_id": "110000000000",
+                "district_id": "11000"
+            },
+            {
+                "name": "Berlin-Mitte",
+                "place_id": "110010000000",
+                "district_id": "11001"
+            },
+            {
+                "name": "Darmstadt, Wissenschaftsstadt",
+                "place_id": "064110000000",
+                "district_id": "06411"
+            }
+        ],
+        "language": "german"
+    }
+}


### PR DESCRIPTION
Problem with CovidRules fixed. 
Nina API sends us covid rules in a list. 
Each index is a different rule: f.e: 0 = vaccine infos, 1 = contact_terms, 2 = school_kita_rules.
We thought that the list always has a lenght of 6 but thats not the case.
Now we check if the index exists before accessing it. 

The corresponding field in the CovidRules class can be None now